### PR TITLE
Added memory opcodes: we now generate the code and support the parsin…

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -69,6 +69,8 @@ enum OPERATION {
   EXTEND_OPER,
   DEMOTE_OPER,
   PROMOTE_OPER,
+  STORE_OPER,
+  LOAD_OPER,
 };
 
 #endif

--- a/src/expression.h
+++ b/src/expression.h
@@ -217,7 +217,7 @@ class CallExpression : public Expression {
       return call_id_;
     }
 
-    llvm::Function* GetCallee(WasmFunction* fct) const;
+    WasmFunction* GetCallee(WasmFunction* fct) const;
 
     virtual void Dump(int tabs) const {
       BISON_PRINT("(Call ");

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -216,6 +216,8 @@ void WasmFunction::Generate(WasmModule* module) {
     if (is_last_return == false && last != nullptr) {
       HandleReturn(last, builder);
     }
+  } else {
+    builder.CreateRetVoid();
   }
 }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,0 +1,177 @@
+/*
+// Copyright (c) 2015 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "memory.h"
+
+llvm::Type* MemoryExpression::GetAddressType() const {
+  llvm::Type* type = nullptr;
+
+  if (type_ == INT_32 || type_ == INT_64) {
+    switch (size_) {
+      case 8:
+        type = llvm::Type::getInt8Ty(llvm::getGlobalContext());
+        break;
+      case 16:
+        type = llvm::Type::getInt16Ty(llvm::getGlobalContext());
+        break;
+      case 32:
+        type = llvm::Type::getInt32Ty(llvm::getGlobalContext());
+        break;
+      case 64:
+        type = llvm::Type::getInt64Ty(llvm::getGlobalContext());
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (size_) {
+      case 32:
+        type = llvm::Type::getFloatTy(llvm::getGlobalContext());
+        break;
+      case 64:
+        type = llvm::Type::getDoubleTy(llvm::getGlobalContext());
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+
+  return type;
+}
+
+llvm::Value* MemoryExpression::GetPointer(WasmFunction*fct, llvm::IRBuilder<>& builder) const {
+  llvm::Value* address_i = address_->Codegen(fct, builder);
+  llvm::Type* type = nullptr;
+
+  if (type_ == INT_32 || type_ == INT_64) {
+    switch (size_) {
+      case 8:
+        type = llvm::Type::getInt8PtrTy(llvm::getGlobalContext());
+        break;
+      case 16:
+        type = llvm::Type::getInt16PtrTy(llvm::getGlobalContext());
+        break;
+      case 32:
+        type = llvm::Type::getInt32PtrTy(llvm::getGlobalContext());
+        break;
+      case 64:
+        type = llvm::Type::getInt64PtrTy(llvm::getGlobalContext());
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  } else {
+    switch (size_) {
+      case 32:
+        type = llvm::Type::getFloatPtrTy(llvm::getGlobalContext());
+        break;
+      case 64:
+        type = llvm::Type::getDoublePtrTy(llvm::getGlobalContext());
+        break;
+      default:
+        assert(0);
+        break;
+    }
+  }
+
+  assert(type != nullptr);
+  return builder.CreateIntToPtr(address_i, type, "ptr");
+}
+
+llvm::Value* Load::ResizeIntegerIfNeed(llvm::Value* value,
+                                        llvm::Type* value_type,
+                                        ETYPE destination_type,
+                                        bool sign,
+                                        llvm::IRBuilder<>& builder) {
+  // Get size differences.
+  int value_type_bw = value_type->getIntegerBitWidth();
+  size_t type_size = GetTypeSize(type_);
+
+  if (value_type_bw != type_size) {
+    // Then it depends on sign.
+    value = HandleIntegerTypeCast(value, ConvertType(type_),
+                                  value_type_bw, 
+                                  type_size,
+                                  sign, builder);
+  }
+
+  return value;
+}
+
+llvm::Value* Load::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
+  llvm::Value* address = GetPointer(fct, builder);
+
+  // Create the load.
+  llvm::Value* value = builder.CreateLoad(address, "load");
+
+  // Now we need to convert this load to a size potentially.
+  switch (type_) {
+    case INT_32:
+    case INT_64:
+      value = ResizeIntegerIfNeed(value, value->getType(), type_, sign_, builder);
+      break;
+    case FLOAT_32:
+    case FLOAT_64:
+      assert(GetTypeSize(type_) == size_);
+      break;
+    default:
+      assert(0);
+      break;
+  }
+
+  return value;
+}
+
+llvm::Value* Store::ResizeIntegerIfNeed(llvm::Value* value,
+                                        llvm::Type* value_type,
+                                        llvm::Type* address_type,
+                                        bool sign,
+                                        llvm::IRBuilder<>& builder) {
+  // Get size differences.
+  int value_type_bw = value_type->getIntegerBitWidth();
+
+  if (value_type_bw != size_) {
+    // Then it depends on sign.
+    value = HandleIntegerTypeCast(value, GetAddressType(),
+                                  value_type_bw, size_,
+                                  sign, builder);
+  }
+
+  return value;
+}
+
+llvm::Value* Store::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
+  llvm::Value* address = GetPointer(fct, builder);
+  llvm::Value* value = value_->Codegen(fct, builder);
+
+  // Check if the type of what we are storing is the same type as what we have like size.
+  llvm::Type* address_type = address->getType();
+  llvm::Type* value_type = value->getType();
+
+  llvm::Type::TypeID address_type_id = address_type->getTypeID();
+  llvm::Type::TypeID value_type_id = value_type->getTypeID();
+
+  if (value_type_id == llvm::Type::IntegerTyID) {
+    value = ResizeIntegerIfNeed(value, value_type, address_type, sign_, builder);
+  } else {
+    assert(GetTypeSize(type_) == size_);
+  }
+
+  return builder.CreateStore(value, address, "store");
+}

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,174 @@
+/*
+// Copyright (c) 2015 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+#ifndef H_MEMORY
+#define H_MEMORY
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Intrinsics.h"
+
+#include "base_expression.h"
+#include "enums.h"
+#include "operation.h"
+#include "simple.h"
+
+class MemoryExpression : public Expression {
+  protected:
+    Expression* address_;
+    size_t size_;
+    bool sign_;
+    ETYPE type_;
+
+  public:
+    MemoryExpression(size_t size) : address_(nullptr), size_(size), sign_(0), type_(VOID) {
+    }
+
+    MemoryExpression(Expression* address = nullptr, size_t size = 0, bool sign = false, ETYPE type = VOID) : address_(address), size_(size), sign_(sign), type_(type) {
+    }
+
+    void SetType(ETYPE t) {
+      type_ = t;
+    }
+
+    void SetSign(bool b) {
+      sign_ = b;
+    }
+
+    void SetAddress(Expression* address) {
+      address_ = address;
+    }
+
+    void SetSize(size_t size) {
+      size_ = size;
+    }
+
+    virtual void Dump(int tabs) const {
+      BISON_TABBED_PRINT(tabs, "(%s.memory operation", GetETypeName(type_));
+
+      if (address_) {
+        address_->Dump(0);
+      } else {
+        BISON_PRINT("Address is nullptr");
+      }
+
+      BISON_PRINT(")");
+    }
+
+    llvm::Value* GetPointer(WasmFunction* fct, llvm::IRBuilder<>& builder) const;
+    llvm::Type* GetAddressType() const;
+
+    void UpdateSize() {
+      if (size_ == 0) {
+        // If we don't have a size, get the size of the type_.
+        size_ = GetTypeSize(type_);
+      }
+    }
+};
+
+class Store : public MemoryExpression {
+  protected:
+    Expression* value_;
+
+    llvm::Value* ResizeIntegerIfNeed(llvm::Value* value,
+                                     llvm::Type* value_type,
+                                     llvm::Type* address_type,
+                                     bool sign,
+                                     llvm::IRBuilder<>& builder);
+
+  public:
+    Store(Expression* add, Expression* value) : 
+      MemoryExpression(add), value_(value) {
+    }
+
+    Store() : MemoryExpression() {
+    }
+
+    Store(size_t size) : MemoryExpression(size) {
+    }
+
+    void SetValue(Expression* value) {
+      value_ = value;
+    }
+
+    virtual llvm::Value* Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder);
+
+    virtual void Dump(int tabs) const {
+      BISON_TABBED_PRINT(tabs, "(%s.store", GetETypeName(type_));
+
+      if (size_ != 0) {
+        BISON_PRINT("%lu", size_);
+      }
+
+      BISON_PRINT("_%c ", sign_ ? 's' : 'u');
+
+      if (address_) {
+        address_->Dump(0);
+      } else {
+        BISON_PRINT("Address is nullptr");
+      }
+
+      BISON_PRINT(" ");
+
+      if (value_) {
+        value_->Dump(0);
+      } else {
+        BISON_PRINT("nullptr");
+      }
+
+      BISON_PRINT(")");
+    }
+};
+
+class Load : public MemoryExpression {
+  protected:
+
+    llvm::Value* ResizeIntegerIfNeed(llvm::Value* value,
+                                     llvm::Type* value_type,
+                                     ETYPE destination_type,
+                                     bool sign,
+                                     llvm::IRBuilder<>& builder);
+
+  public:
+    Load() : MemoryExpression() {
+    }
+
+    Load(size_t size) : MemoryExpression(size) {
+    }
+
+    virtual llvm::Value* Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder);
+
+    virtual void Dump(int tabs) const {
+      BISON_TABBED_PRINT(tabs, "(%s.load", GetETypeName(type_));
+
+      if (size_ != 0) {
+        BISON_PRINT("%lu", size_);
+      }
+
+      BISON_PRINT("_%c ", sign_ ? 's' : 'u');
+
+      if (address_) {
+        address_->Dump(0);
+      } else {
+        BISON_PRINT("Address is nullptr");
+      }
+
+      BISON_PRINT(")");
+    }
+};
+
+#endif

--- a/src/module.h
+++ b/src/module.h
@@ -57,10 +57,11 @@ class WasmModule {
     std::vector<WasmFunction*> vector_functions_;
 
     std::string name_;
+    int memory_;
 
   public:
     WasmModule(llvm::Module* module = nullptr, llvm::legacy::PassManager* fpm = nullptr, WasmFile* file = nullptr) :
-      module_(module), fpm_(fpm), file_(file) {
+      module_(module), fpm_(fpm), file_(file), memory_(0) {
         static int cnt = 0;
         std::ostringstream oss;
         oss << "wasm_module_" << cnt;
@@ -97,6 +98,11 @@ class WasmModule {
       raw_fd_ostream file(oss.str().c_str(), ec, of); 
       module_->print(file, NULL); 
       file.close(); 
+    }
+
+    void AddMemory(size_t value) {
+      assert(memory_ == 0);
+      memory_ = value;
     }
 
     void Generate();

--- a/src/operation.h
+++ b/src/operation.h
@@ -61,7 +61,7 @@ class Operation {
     }
 
     virtual void Dump() {
-      BISON_PRINT("%s.%s", DumpOperation(op_), GetETypeName(type_));
+      BISON_PRINT("%s.%s", GetETypeName(type_), DumpOperation(op_));
     }
 };
 

--- a/src/opt.flex
+++ b/src/opt.flex
@@ -173,6 +173,11 @@ max {
   return MAX;
 }
 
+memory {
+  LEX_DEBUG_PRINT("MEMORY\n");
+  return MEMORY;
+}
+
 min {
   LEX_DEBUG_PRINT("MIN\n");
   yylval.l = MIN_OPER;
@@ -367,6 +372,17 @@ param {
   return PARAM_TOKEN;
 }
 
+store {
+  LEX_DEBUG_PRINT("STORE\n");
+  yylval.l = STORE_OPER;
+  return STORE;
+}
+
+load {
+  LEX_DEBUG_PRINT("LOAD\n");
+  yylval.l = LOAD_OPER;
+  return LOAD;
+}
 
 f32 {
   LEX_DEBUG_PRINT("Type %s\n", yytext);

--- a/src/opt.ypp
+++ b/src/opt.ypp
@@ -29,6 +29,7 @@
 #include "function_field.h"
 #include "globals.h"
 #include "local.h"
+#include "memory.h"
 #include "module.h"
 #include "operation.h"
 #include "simple.h"
@@ -49,9 +50,11 @@ std::unique_ptr<Globals> g_variables;
   enum ETYPE;
   class FunctionField;
   class Globals;
+  class Load;
   class Local;
   class Operation;
   enum OPERATION;
+  class Store;
   class ValueHolder;
   class Variable;
   class WasmAssert;
@@ -78,10 +81,12 @@ std::unique_ptr<Globals> g_variables;
   Expression* ex;
   WasmFunction* f;
   FunctionField* ff;
+  Load* ld;
   Local* local;
   WasmModule* m;
   Operation* o;
   OPERATION op;
+  Store* st;
   Variable* v;
   ValueHolder* vh;
   WasmAssert* wa;
@@ -110,6 +115,7 @@ std::unique_ptr<Globals> g_variables;
 %token LOCAL_TOKEN
 %token CONST
 %token LABEL
+%token MEMORY STORE LOAD
 
 %type<voidptr> FUNCTION_FIELDS
 %type<voidptr> EXPRESSIONS
@@ -118,20 +124,23 @@ std::unique_ptr<Globals> g_variables;
 %type<co> POTENTIAL_SIGNED_CONVERSION
 %type<e> EXPORT
 %type<et> TYPE
-%type<ex> CALL BREAK BLOCK
+%type<ex> CALL BREAK BLOCK MEMORY_OPERATION
 %type<ex> EXPRESSION EXPRESSION_INNER EXPRESSION_OR_NOT
 %type<f> FUNCTION
 %type<ff> SIMPLE_FIELD FUNCTION_FIELD
 %type<l> RESULT INTEGER
+%type<ld> POTENTIAL_SIGNED_LOAD LOAD_POTENTIAL_SIZE 
 %type<local> TYPE_LIST PARAM LOCAL LOCAL_ELEMS
 %type<m> MODULE MODULE_ELEMS
-%type<o> BINOP UNOP
+%type<o> BINOP UNOP 
 %type<o> POTENTIAL_SIGNED_BINOP POTENTIAL_SIGNED_UNOP POTENTIAL_SIGNED_TRUNC
+%type<op> LOAD STORE
 %type<op> BINOP_OPER UNOP_OPER
 %type<op> NE EQ DIV ADD SUB MUL REM AND OR XOR SHL SHR CLZ CTZ POPCNT
 %type<op> LE LT GE GT
-%type<op> SQRT MAX MIN CEIL FLOOR TRUNC NEAREST ABS NEG COPYSIGN
+%type<op> SQRT MAX MIN CEIL FLOOR TRUNC NEAREST ABS NEG COPYSIGN 
 %type<op> WRAP EXTEND CONVERT PROMOTE DEMOTE REINTERPRET CONVERSION
+%type<st> POTENTIAL_SIGNED_STORE STORE_POTENTIAL_SIZE
 %type<string> IDENTIFIER_OR_NOT IDENTIFIER STRING
 %type<string> FLOAT
 %type<v> VARIABLE_OR_NOT VARIABLE
@@ -194,6 +203,11 @@ MODULE_ELEMS:
     WasmModule* module = $2;
     WasmExport* e = $1;
     module->AddExport(e);
+    $$ = module;
+  } | 
+   '(' MEMORY INTEGER ')' MODULE_ELEMS {
+    WasmModule* module = $5;
+    module->AddMemory($3);
     $$ = module;
   } | {
     $$ = new WasmModule();
@@ -458,6 +472,49 @@ BLOCK:
     $$ = new BlockExpression(list);
   }
 
+LOAD_POTENTIAL_SIZE:
+  LOAD { $$ = new Load(); } |
+  LOAD INTEGER { $$ = new Load($2); }
+
+POTENTIAL_SIGNED_LOAD:
+  LOAD_POTENTIAL_SIZE { $$ = $1; } |
+  LOAD_POTENTIAL_SIZE '_' SIGN { 
+    Load* ld = $1;
+    ld->SetSign($3);
+    $$ = ld;
+  }
+
+STORE_POTENTIAL_SIZE:
+  STORE { $$ = new Store(); } |
+  STORE INTEGER { $$ = new Store($2); }
+
+POTENTIAL_SIGNED_STORE:
+  STORE_POTENTIAL_SIZE { $$ = $1; } |
+  STORE_POTENTIAL_SIZE '_' SIGN {
+    Store* st = $1;
+    st->SetSign($3);
+    $$ = st;
+  }
+
+MEMORY_OPERATION:
+  TYPE '.' POTENTIAL_SIGNED_LOAD EXPRESSION { 
+    Load* ld = $3;
+    ld->SetType($1);
+    ld->SetAddress($4); 
+
+    // Size might need to get updated here.
+    ld->UpdateSize();
+    $$ = ld; } |
+  TYPE '.' POTENTIAL_SIGNED_STORE EXPRESSION EXPRESSION {
+    Store* st = $3;
+    st->SetType($1);
+    st->SetAddress($4);
+    st->SetValue($5); 
+
+    // Size might need to get updated here.
+    st->UpdateSize();
+    $$ = st; }
+
 EXPRESSION_INNER:
     NOP { $$ = nullptr; } |
     BINOP EXPRESSION EXPRESSION {
@@ -517,6 +574,7 @@ EXPRESSION_INNER:
       LoopExpression* loop = new LoopExpression(expr);
       $$ = loop;
     } |
+    MEMORY_OPERATION { $$ = $1; } |
     BREAK { $$ = $1; } |
     BLOCK { $$ = $1; } |
     RETURN_TOKEN EXPRESSION {

--- a/src/unop.cpp
+++ b/src/unop.cpp
@@ -120,9 +120,10 @@ llvm::Value* Unop::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
         }
         return builder.CreateFSub(lv, rv, "subtmp");
       }
-      case REINTERPRET_OPER: {
+
+      case REINTERPRET_OPER:
         return builder.CreateBitCast(rv, ConvertType(type), DumpOperation(op));
-      }
+
       case EXTEND_OPER: 
       case TRUNC_OPER:
       case PROMOTE_OPER:
@@ -133,6 +134,7 @@ llvm::Value* Unop::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
         assert(conversion != nullptr);
         return HandleTypeCasts(rv, ConvertType(conversion->GetSrc()), ConvertType(type), operation_->GetSignedOrOrdered(), builder);
       }
+      
       default:
         assert(0);
         return nullptr;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 
+#include "debug.h"
 #include "utility.h"
 
 const char* GetETypeName(ETYPE type) {
@@ -38,6 +39,20 @@ const char* GetETypeName(ETYPE type) {
       return "ptr64";
   }
   return "Unknown";
+}
+
+size_t GetTypeSize(ETYPE type) {
+  switch (type) {
+    case FLOAT_32:
+    case INT_32:
+      return 32;
+    case FLOAT_64:
+    case INT_64:
+      return 64;
+    default:
+      assert(0);
+  }
+  return 0;
 }
 
 const char* DumpOperation(OPERATION op) {
@@ -253,7 +268,7 @@ llvm::Value* HandleTypeCasts(llvm::Value* value, llvm::Type* src_type, llvm::Typ
         return value;
       default: {
         llvm::Type::TypeID dest_type_id = dest_type->getTypeID();
-        fprintf(stderr, "HandleTypeCast failure: destination is %d and src is %d\n", dest_type_id, src_type_id);
+        BISON_PRINT("HandleTypeCast failure: destination is %d and src is %d\n", dest_type_id, src_type_id);
         assert(0);
         break;
       }
@@ -318,6 +333,10 @@ ETYPE ConvertTypeID2ETYPE(llvm::Type* type) {
           return INT_32;
         case 64:
           return INT_64;
+        default:
+          // Should never get here.
+          assert(0);
+          break;
       }
   }
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -27,6 +27,7 @@ const char* DumpOperation(OPERATION op);
 // Conversion of enumeration type to LLVM type.
 ETYPE ConvertTypeID2ETYPE(llvm::Type* type);
 llvm::Type* ConvertType(ETYPE type);
+size_t GetTypeSize(ETYPE type);
 
 // Code generation for type conversion.
 llvm::Value* HandleSimpleTypeCasts(llvm::Value* value, llvm::Type* dest_type, bool sign, llvm::IRBuilder<>& builder);


### PR DESCRIPTION
…g of the endianness test but

  it would segfault if ran because there is no memory allocated so we'd try to load/store non
  allocated addresses.
- Binop:
  - Lower div and shift now have type passed down to them
    (Helps dumping)
- enums.h:
  - Added store/load operators
- expression:
  - Callee handling is a bit smarter now: it can handle no return calls
- memory:
  - Memory opcode handling: not really tested, we do support the endianness test
    - When I write support, please read: LLVM does not crash when generating the code...
- module:
  - Has the concept of a linear memory request and registers how much it wants
- operation.h:
  - Conforming to type.operation print out
- opt.flex/opt.ypp:
  - Added memory store/load operations
- utility:
  - Added GetTypeSize method and cleaned up a bit.
