### PR TITLE
Added back the test system and the wrapper but now:

### DIFF
--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -1,0 +1,55 @@
+/*
+// Copyright (c) 2015 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <limits>
+
+
+extern "C" {
+  int execute_asserts(void);
+
+  // Wrapper around the assert trap.
+  int wp_assert_trap_handler(char* (*fct)(void)) {
+    int idx = 0;
+    char* exception = nullptr;
+
+    static int cnt = 0;
+
+    // Only print this out once...
+    if (cnt == 0) {
+      std::cerr << "Currently the trapping system does not work, ignoring" << std::endl;
+      cnt++;
+    }
+    return -1;
+  }
+}
+
+int main(void) {
+  int res = -1;
+  res = execute_asserts();
+
+  if (res == -1) {
+    return EXIT_SUCCESS;
+    fprintf(stderr, "Executed assertion, success\n");
+  } else {
+    fprintf(stderr, "Executed assertion, failure for assertion line %d\n", res);
+    return EXIT_FAILURE;
+  }
+}

--- a/wrapper/run.sh
+++ b/wrapper/run.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright (c) 2015 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Running tests"
+
+list=`cat wrapper/supported | grep -v '#'`
+echo "Test list is:"
+echo $list
+
+exe=llvm_wasm
+
+if [ ! -e $exe ]; then
+  echo "Build llvm_wasm first"
+  exit 1
+fi
+
+for name in $list; do
+  f="testsuite/$name"
+  echo $f
+
+  if [ ! -e $f ]; then
+    echo "Skipping $f, does not exist"
+  else
+    # Clean up
+    rm obj/*ll obj/*s
+
+    # Build the llvm IR
+    $exe $f
+
+    if [ $? -ne 0 ]; then
+      echo "LLVM transformation of $f failed. Bailing."
+      exit 1
+    fi
+
+    # Create the .s files
+    for ll in obj/*ll; do
+      llc-3.7 $ll
+
+      if [ $? -ne 0 ]; then
+        echo "LLVM transformation of $ll failed. Bailing."
+        exit 1
+      fi
+    done
+
+    # Create the test exec.
+    g++ obj/wasm_module*s wrapper/main.cpp -o obj/testit -std=gnu++0x
+
+    if [ $? -ne 0 ]; then
+      echo "Build of test $f failed. Bailing."
+      exit 1
+    fi
+
+    # Run the test.
+    obj/testit
+
+    if [ $? -ne 0 ]; then
+      echo "Test failed: $f. Bailing."
+      exit 1
+    fi
+  fi
+done
+
+echo "Tests passed"

--- a/wrapper/supported
+++ b/wrapper/supported
@@ -1,0 +1,14 @@
+conversions.wast
+f32.wast
+f32_cmp.wast
+f64.wast
+f64_cmp.wast
+fac.wast
+# Can't yet due to multiple functions with the same names:
+# float_exprs.wast
+float_literals.wast
+float_misc.wast
+i32.wast
+i64.wast
+int_exprs.wast
+int_literals.wast


### PR DESCRIPTION
- wrapper/supported contains the test we now support in the testsuite folder
  - We have regressed on the float_exprs.wast until the same function name usage is resolved.
