### PR TITLE
Fixed warnings (and some really bad ones :)).

### DIFF
--- a/src/parser/base_expression.h
+++ b/src/parser/base_expression.h
@@ -44,6 +44,10 @@ class Expression {
 
     virtual llvm::Value* Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
       BISON_PRINT("No code generation for this expression node\n");
+
+      (void) fct;
+      (void) builder;
+
       return nullptr;
     }
 };

--- a/src/parser/binop.h
+++ b/src/parser/binop.h
@@ -29,10 +29,10 @@
 
 class Binop : public Expression {
   protected:
-    Expression *left_, *right_;
     Operation* operation_;
+    Expression *left_, *right_;
 
-    ETYPE HandleType(ETYPE type, llvm::Type* lt, llvm::Type* rt);
+    ETYPE HandleType(llvm::Type* lt, llvm::Type* rt);
     llvm::Value* HandleInteger(llvm::Value* lv, llvm::Value* rv, llvm::IRBuilder<>& builder);
     llvm::Value* HandleShift(WasmFunction* fct, llvm::IRBuilder<>& builder, bool sign, bool right);
     llvm::Value* HandleDivRem(WasmFunction* fct, llvm::IRBuilder<>& builder, bool sign, bool div);
@@ -53,11 +53,11 @@ class Binop : public Expression {
       return left_;
     }
 
-    Expression* SetRight(Expression* r) {
+    void SetRight(Expression* r) {
       right_ = r;
     }
 
-    Expression* SetLeft(Expression* l) {
+    void SetLeft(Expression* l) {
       left_ = l;
     }
 

--- a/src/parser/expression.cpp
+++ b/src/parser/expression.cpp
@@ -83,6 +83,10 @@ llvm::Value* Const::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
       assert(0);
       break;
   }
+
+  (void) fct;
+  (void) builder;
+
   return nullptr;
 }
 
@@ -225,7 +229,7 @@ llvm::Value* LabelExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& buil
   fct->PushLabel(end_label);
 
   // Generate the code now.
-  expr_->Codegen(fct, builder);
+  llvm::Value* res = expr_->Codegen(fct, builder);
 
   // Now jump to the end_label.
   builder.CreateBr(end_label);
@@ -239,12 +243,11 @@ llvm::Value* LabelExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& buil
 
   // Finally pop the label.
   fct->PopLabel();
+
+  return res;
 }
 
 llvm::Value* LoopExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
-  // For now, just ignore it for code generation.
-  llvm::BasicBlock* preheader = builder.GetInsertBlock();
-
   // The other two will wait before being emitted.
   const char* name = (var_ != nullptr) ? var_->GetString() : "loop_block";
   llvm::BasicBlock* loop = BasicBlock::Create(llvm::getGlobalContext(), name, fct->GetFunction());
@@ -319,7 +322,7 @@ llvm::Value* ReturnExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& bui
   // Generate the code for the return, then call the handler.
   llvm::Value* result = result_->Codegen(fct, builder);
   assert(result != nullptr);
-  fct->HandleReturn(result, builder);
+  return fct->HandleReturn(result, builder);
 }
 
 llvm::Value* Unreachable::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {

--- a/src/parser/expression.h
+++ b/src/parser/expression.h
@@ -30,14 +30,17 @@ class WasmFunction;
 class Nop : public Expression {
   public:
     virtual llvm::Value* Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
+      (void) fct;
+      (void) builder;
+
       return nullptr;
     }
 };
 
 class Unop : public Expression {
   protected:
-    Expression* only_;
     Operation* operation_;
+    Expression* only_;
 
   public:
     Unop(Operation* op, Expression* only) :
@@ -253,7 +256,7 @@ class CallExpression : public Expression {
     WasmFunction* GetCallee(WasmFunction* fct) const;
 
     virtual void Dump(int tabs = 0) const {
-      BISON_PRINT("(Call ");
+      BISON_TABBED_PRINT(tabs, "(Call ");
       if (call_id_) {
         call_id_->Dump();
       } else {
@@ -478,6 +481,8 @@ class StringExpression : public Expression {
     }
 
     virtual llvm::Value* Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
+      (void) fct;
+
       return builder.CreateGlobalStringPtr(s_);
     }
 };
@@ -495,6 +500,9 @@ class ValueExpression : public Expression {
     }
 
     virtual llvm::Value* Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
+      (void) fct;
+      (void) builder;
+
       return value_;
     }
 };

--- a/src/parser/function.cpp
+++ b/src/parser/function.cpp
@@ -308,11 +308,13 @@ llvm::BasicBlock* WasmFunction::GetLabel(const char* name) {
 }
 
 void WasmFunction::MangleNames(WasmFile* file, WasmModule* module) {
+  (void) file;
+
   // First mangle the function name.
-  MangleFunctionName(file, module);
+  MangleFunctionName(module);
 }
 
-void WasmFunction::MangleFunctionName(WasmFile* file, WasmModule* module) {
+void WasmFunction::MangleFunctionName(WasmModule* module) {
   std::ostringstream oss;
 
   // We start by mangling it using the module hash.

--- a/src/parser/function.h
+++ b/src/parser/function.h
@@ -64,7 +64,8 @@ class WasmFunction {
   public:
     WasmFunction(std::list<FunctionField*>* f = nullptr, const std::string& s = "anonymous",
                  llvm::Function* fct = nullptr, WasmModule* module = nullptr, ETYPE result = VOID) :
-      name_(s), fct_(fct), module_(module), fields_(f), result_(result), local_base_(nullptr) {
+      name_(s), fct_(fct), fields_(f), module_(module), result_(result), local_base_(nullptr) 
+      {
         // If anonymous, let's add a unique suffix.
         if (name_ == "anonymous") {
           static int cnt = 0;
@@ -146,7 +147,7 @@ class WasmFunction {
     llvm::Value* HandleReturn(llvm::Value* result, llvm::IRBuilder<>& builder) const;
 
     void MangleNames(WasmFile* file, WasmModule* module);
-    void MangleFunctionName(WasmFile* file, WasmModule* module);
+    void MangleFunctionName(WasmModule* module);
 };
 
 #endif

--- a/src/parser/local.h
+++ b/src/parser/local.h
@@ -85,6 +85,8 @@ class Local {
       }
 
       BISON_PRINT(")");
+
+      (void) prefix;
     }
 
     const std::list<LocalElem*>& GetList() const {

--- a/src/parser/memory.h
+++ b/src/parser/memory.h
@@ -86,7 +86,6 @@ class Store : public MemoryExpression {
 
     llvm::Value* ResizeIntegerIfNeed(llvm::Value* value,
                                      llvm::Type* value_type,
-                                     llvm::Type* address_type,
                                      bool sign,
                                      llvm::IRBuilder<>& builder);
 
@@ -139,7 +138,6 @@ class Load : public MemoryExpression {
 
     llvm::Value* ResizeIntegerIfNeed(llvm::Value* value,
                                      llvm::Type* value_type,
-                                     ETYPE destination_type,
                                      bool sign,
                                      llvm::IRBuilder<>& builder);
 

--- a/src/parser/operation.h
+++ b/src/parser/operation.h
@@ -23,8 +23,8 @@
 class Operation {
   protected:
     OPERATION op_;
-    ETYPE type_;
     bool sign_or_order_;
+    ETYPE type_;
 
   public:
     Operation(OPERATION o, bool sign_or_order, ETYPE t) : op_(o), sign_or_order_(sign_or_order), type_(t) {
@@ -82,11 +82,11 @@ class ConversionOperation : public Operation {
       return op_;
     }
 
-    ETYPE SetDest(ETYPE val) {
+    void SetDest(ETYPE val) {
       type_ = val;
     }
 
-    ETYPE SetSrc(ETYPE val) {
+    void SetSrc(ETYPE val) {
       src_ = val;
     }
 

--- a/src/parser/simple.h
+++ b/src/parser/simple.h
@@ -252,7 +252,13 @@ class ValueHolder {
           type_ = VH_DOUBLE;
         }
         break;
+
+        default:
+         assert(0);
+         break;
       }
+
+      return true;
     }
 };
 

--- a/src/parser/unop.cpp
+++ b/src/parser/unop.cpp
@@ -51,7 +51,6 @@ llvm::Value* Unop::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
 
   if (is_intrinsic == true) {
     WasmModule* wasm_module = fct->GetModule();
-    llvm::Module* module = wasm_module->GetModule();
     ETYPE type = operation_->GetType();
     llvm::Intrinsic::ID intrinsic;
 

--- a/src/parser/wasm_script.cpp
+++ b/src/parser/wasm_script.cpp
@@ -17,7 +17,7 @@
 #include "wasm_script.h"
 #include "wasm_file.h"
 
-static CallExpression* HandleInvoke(WasmModule* wasm_module, WasmScriptElem* elem) {
+static CallExpression* HandleInvoke(WasmScriptElem* elem) {
   const std::string& name = elem->GetName();
 
   // Generate the call.
@@ -37,7 +37,7 @@ static CallExpression* HandleAssert(WasmModule* wasm_module, WasmScriptElem* ele
   //   or go via a handler and pass the wasm_assert method.
   if (dynamic_cast<WasmAssertReturn*>(elem) != nullptr) {
     // In this case, we can handle it as if it's just an invoke.
-    return HandleInvoke(wasm_module, elem);
+    return HandleInvoke(elem);
   } else {
     // In the assert_trap case, we want to actually call the assert_trap_handler method.
     // Generate the call.
@@ -98,7 +98,7 @@ void WasmScript::GenerateGeneralScriptCalls(WasmFile* file) {
     Expression* expr = nullptr;
 
     if (dynamic_cast<WasmInvoke*>(elem) != nullptr) {
-      expr = HandleInvoke(wasm_module, elem);
+      expr = HandleInvoke(elem);
     } else {
       CallExpression* call = HandleAssert(wasm_module, elem);
 

--- a/src/parser/wasm_script_elem.h
+++ b/src/parser/wasm_script_elem.h
@@ -68,6 +68,7 @@ class WasmScriptElem {
     }
 
     virtual void Codegen(WasmFile* file) {
+      (void) file;
       BISON_PRINT("No codegen for this script element: %s\n", name_.c_str());
     }
 


### PR DESCRIPTION
- Code now compiles without warnings in -Wall -Wextra but I need to remove that due
  to LLVM having issues when compiling like that (two unused parameters).
