### PR TITLE
- Kept the Wasm block names for the label branching

### DIFF
--- a/src/parser/expression.cpp
+++ b/src/parser/expression.cpp
@@ -251,7 +251,7 @@ llvm::Value* LabelExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& buil
   // For now, just ignore it for code generation.
   llvm::BasicBlock* end_label = BasicBlock::Create(llvm::getGlobalContext(), name);
 
-  fct->PushLabel(end_label);
+  fct->PushLabel(name, end_label);
   fct->RegisterNamedExpression(end_label, this);
 
   // Generate the code now.
@@ -288,8 +288,8 @@ llvm::Value* LoopExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& build
   llvm::BasicBlock* exit_block = BasicBlock::Create(llvm::getGlobalContext(), exit_name, fct->GetFunction());
 
   // Push it.
-  fct->PushLabel(exit_block);
-  fct->PushLabel(loop);
+  fct->PushLabel(exit_name, exit_block);
+  fct->PushLabel(name, loop);
 
   // Also register for the function level that this loop is this exit block.
   fct->RegisterNamedExpression(exit_block, this);
@@ -366,10 +366,10 @@ llvm::Value* NamedExpression::HandlePhiNodes(llvm::IRBuilder<>& builder) const {
 llvm::Value* BlockExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
   llvm::Value* res = nullptr;
 
-  const char* name = name_ ? name_ : "unamed_exit_block";
   BasicBlock* block_code  = BasicBlock::Create(llvm::getGlobalContext(), "block", fct->GetFunction());
 
   // Create the exit block.
+  const char* name = name_ ? name_ : "unamed_exit_block";
   BasicBlock* exit_block_code  = BasicBlock::Create(llvm::getGlobalContext(), name, fct->GetFunction());
 
   builder.CreateBr(block_code);
@@ -377,7 +377,7 @@ llvm::Value* BlockExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& buil
   builder.SetInsertPoint(block_code);
 
   // Push it.
-  fct->PushLabel(exit_block_code);
+  fct->PushLabel(name, exit_block_code);
 
   // Also register for the function level that this loop is this exit block.
   fct->RegisterNamedExpression(exit_block_code, this);

--- a/src/parser/function.cpp
+++ b/src/parser/function.cpp
@@ -307,6 +307,14 @@ llvm::BasicBlock* WasmFunction::GetLabel(size_t from_last) {
 }
 
 llvm::BasicBlock* WasmFunction::GetLabel(const char* name) {
+  // First loop if we find it in the mapped association.
+  std::map<std::string, llvm::BasicBlock*>::const_iterator it;
+  it = mapped_labels_.find(name);
+
+  if (it != mapped_labels_.end()) {
+    return it->second;
+  }
+
   for (auto elem : labels_) {
     if (elem->getName() == name) {
       return elem;

--- a/src/parser/function.h
+++ b/src/parser/function.h
@@ -48,6 +48,7 @@ class WasmFunction {
     WasmModule* module_;
 
     std::vector<llvm::BasicBlock*> labels_;
+    std::map<std::string, llvm::BasicBlock*> mapped_labels_;
 
     // We have redundancy-ish here: since Wasm can do index or named, this helps make it
     //   transparent and easier to maintain.
@@ -93,7 +94,8 @@ class WasmFunction {
       return iter->second;
     }
 
-    void PushLabel(llvm::BasicBlock* bb) {
+    void PushLabel(const std::string& name, llvm::BasicBlock* bb) {
+      mapped_labels_[name] = bb;
       labels_.push_back(bb);
     }
 

--- a/src/parser/switch_expression.cpp
+++ b/src/parser/switch_expression.cpp
@@ -121,14 +121,14 @@ std::string SwitchExpression::HandleExpressionCase(ExpressionCaseDefinition* exp
 
 llvm::Value* SwitchExpression::Codegen(WasmFunction* fct, llvm::IRBuilder<>& builder) {
   std::vector<BasicBlock*> case_blocks;
-  const char* name = name_ != nullptr ? name_ : "switch_exit";
 
   llvm::BasicBlock* switch_block = builder.GetInsertBlock();
 
+  const char* name = name_ != nullptr ? name_ : "switch_exit";
   llvm::BasicBlock* exit_block = BasicBlock::Create(llvm::getGlobalContext(), name, fct->GetFunction());
 
   // Push it.
-  fct->PushLabel(exit_block);
+  fct->PushLabel(name, exit_block);
   fct->RegisterNamedExpression(exit_block, this);
 
   // Start by generating the cases.

--- a/src/parser/wasm.flex
+++ b/src/parser/wasm.flex
@@ -344,8 +344,8 @@ assert_trap {
   return ASSERT_TRAP_TOKEN;
 }
 
-assert_invalid {
-  LEX_DEBUG_PRINT("ASSERT INVALID\n");
+\(assert_invalid[^\n]* {
+  LEX_DEBUG_PRINT("ASSERT INVALID: %s\n", yytext);
   return ASSERT_INVALID_TOKEN;
 }
 

--- a/src/parser/wasm.ypp
+++ b/src/parser/wasm.ypp
@@ -838,11 +838,7 @@ ASSERT_TRAP:
   }
 
 ASSERT_INVALID:
-  '('
-  ASSERT_INVALID_TOKEN
-  MODULE
-  STRING
-  ')' {
+  ASSERT_INVALID_TOKEN {
     $$ = nullptr;
   }
 

--- a/wrapper/supported
+++ b/wrapper/supported
@@ -25,4 +25,6 @@ left-to-right.wast
 memory_redundancy.wast
 names.wast
 nan-propagation.wast
+switch.wast
+traps.wast
 unreachable.wast


### PR DESCRIPTION
- This allows to have different blocks having the same name when in different loops.
- Changed the way assert_invalid works right now to just ignore what is coming next
  - Both parts allows us to support switch.wast
