### PR TITLE
fix convert error

### DIFF
--- a/src/print_line.cpp
+++ b/src/print_line.cpp
@@ -26,9 +26,7 @@ void PrintLine(const char* name, int line) {
   // Get the line before the parameter.
   int cnt = 0;
   while (cnt < line - 1) {
-    bool b = std::getline(input, s);
-
-    if (b == false) {
+    if (!std::getline(input, s)) {
       std::cerr << "Error finding the error line" << std::endl;
       return;
     }
@@ -36,8 +34,7 @@ void PrintLine(const char* name, int line) {
   }
 
   // Now get the error line.
-  bool b = std::getline(input, s);
-  if (b == false) {
+  if (!std::getline(input, s)) {
     std::cerr << "Error finding the error line" << std::endl;
     return;
   }


### PR DESCRIPTION
This fixes the below compilation errors

```
g++ -c -o obj/print_line.o src/print_line.cpp -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -g -std=gnu++0x -I`llvm-config --includedir` -Isrc/parser -Isrc -Isrc/passes -O3
src/print_line.cpp: In function 'void PrintLine(const char*, int)':
src/print_line.cpp:29:35: error: cannot convert 'std::basic_istream<char>' to 'bool' in initialization
     bool b = std::getline(input, s);
                                   ^
src/print_line.cpp:39:33: error: cannot convert 'std::basic_istream<char>' to 'bool' in initialization
   bool b = std::getline(input, s);
                                 ^
makefile:40: recipe for target 'obj/print_line.o' failed
make: *** [obj/print_line.o] Error 1
```
