### PR TITLE
Remove error message for 'make perf-test' & 'make test'

### DIFF
--- a/perf_tests/run.sh
+++ b/perf_tests/run.sh
@@ -16,7 +16,7 @@
 
 echo "Running perf tests"
 
-exe=llvm_wasm
+exe=${PWD}/llvm_wasm
 
 if [ ! -e $exe ]; then
   echo "Build llvm_wasm first"

--- a/wrapper/run.sh
+++ b/wrapper/run.sh
@@ -25,7 +25,7 @@ fi
 echo "Test list is:"
 echo $list
 
-exe=llvm_wasm
+exe=${PWD}/llvm_wasm
 our_log=obj/test_output
 diff_file=obj/test_output_diff
 


### PR DESCRIPTION
Test scripts generate errors due to unknown location of **llvm_wasm** marked with line below.

> exe=llvm_wasm

The two lines in test paths are prefixed with '${PWD}/' for clarification.
