### PR TITLE
Reset file handling in the grammar

### DIFF
--- a/src/parser/wasm.ypp
+++ b/src/parser/wasm.ypp
@@ -186,19 +186,19 @@ START: FILE {
 }
 
 FILE:
-  FILE MODULE {
+  MODULE FILE {
     // Add the module to the file.
-    WasmModule* module = $2;
-    WasmFile* file = $1;
+    WasmModule* module = $1;
+    WasmFile* file = $2;
     file->AddModule(module);
 
     // Propagate this up.
     $$ = file;
   } |
-  FILE SCRIPT_ELEM {
+  SCRIPT_ELEM FILE {
     // Add a script element.
-    WasmScriptElem* wse = $2;
-    WasmFile* file = $1;
+    WasmScriptElem* wse = $1;
+    WasmFile* file = $2;
 
     if (wse != nullptr) {
       // We want the file to know about the script request.

--- a/src/parser/wasm_file.h
+++ b/src/parser/wasm_file.h
@@ -32,7 +32,6 @@ class WasmFile {
     }
 
     void AddModule(WasmModule* module) {
-      // Currently we only support one module.
       modules_.push_back(module);
       module->SetWasmFile(this);
     }


### PR DESCRIPTION
Reset the way files are done in the grammar otherwise it messes up
  with the assert ordering (could be easily fixed) and
  with the handling of what method to call in the script (trickier).
